### PR TITLE
chore: remove unused deps, add MSRV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,15 +1045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc95de49ad098572c02d3fbf368c9a020bfff5ae78483685b77f51d8a7e9486d"
-dependencies = [
- "num_threads",
-]
-
-[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,15 +2249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ocb3"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,10 +2599,8 @@ name = "picolayer"
 version = "0.2.13"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "dirs-next",
- "env",
  "env_logger",
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "picolayer"
 version = "0.2.13"
 edition = "2024"
+rust-version = "1.85.0"
 authors = ["skevetter"]
 description = "A package installer and script runner that ensures minimal container layers"
 license = "MIT"
@@ -38,7 +39,6 @@ openssl = { version = "0.10", features = ["vendored"] }
 [dependencies]
 anyhow = "1.0.100"
 clap = { version = "4.5.48", features = ["derive"] }
-env = "1.0.1"
 env_logger = "0.11"
 flate2 = "1.1.4"
 hex = "0.4.3"
@@ -67,6 +67,5 @@ which = "8.0.0"
 xz = "0.1.0"
 
 [dev-dependencies]
-chrono = "0.4"
 dirs-next = "2.0.0"
 serial_test = "3.2.0"


### PR DESCRIPTION
## Summary
- Remove unused `env` crate (code uses `std::env`, not this crate)
- Remove unused `chrono` dev-dependency (no longer referenced after octocrab mock rewrite)
- Add `rust-version = "1.85.0"` to Cargo.toml (required by edition 2024)