### PR TITLE
security: fix command injection and harden GPG verification

### DIFF
--- a/src/installers/devcontainer_feature/installer.rs
+++ b/src/installers/devcontainer_feature/installer.rs
@@ -78,6 +78,21 @@ fn load_feature_metadata(feature_dir: &Path) -> Result<Feature> {
     Ok(feature)
 }
 
+/// Safely resolve the home directory for a user via `getent passwd` instead of
+/// shell interpolation (`eval echo ~user`) which is vulnerable to command injection.
+fn get_home_dir_for_user(user: &str) -> Option<String> {
+    let output = Command::new("getent")
+        .args(["passwd", user])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&output.stdout);
+    // getent passwd format: name:password:uid:gid:gecos:home:shell
+    line.trim().split(':').nth(5).map(|s| s.to_string())
+}
+
 fn resolve_remote_user(remote_user: Option<&str>) -> Result<(String, String)> {
     if let Some(user) = remote_user
         && let Ok(output) = Command::new("id").arg("-u").arg(user).output()
@@ -86,13 +101,7 @@ fn resolve_remote_user(remote_user: Option<&str>) -> Result<(String, String)> {
         if let Ok(home) = std::env::var("HOME") {
             return Ok((user.to_string(), home));
         }
-        if let Ok(output) = Command::new("sh")
-            .arg("-c")
-            .arg(format!("eval echo ~{}", user))
-            .output()
-            && output.status.success()
-        {
-            let home = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if let Some(home) = get_home_dir_for_user(user) {
             return Ok((user.to_string(), home));
         }
 
@@ -102,13 +111,8 @@ fn resolve_remote_user(remote_user: Option<&str>) -> Result<(String, String)> {
     for user in ORDERED_BASE_USERS {
         if let Ok(output) = Command::new("id").arg("-u").arg(user).output()
             && output.status.success()
-            && let Ok(output) = Command::new("sh")
-                .arg("-c")
-                .arg(format!("eval echo ~{}", user))
-                .output()
-            && output.status.success()
+            && let Some(home) = get_home_dir_for_user(user)
         {
-            let home = String::from_utf8_lossy(&output.stdout).trim().to_string();
             return Ok((user.to_string(), home));
         }
     }
@@ -118,13 +122,7 @@ fn resolve_remote_user(remote_user: Option<&str>) -> Result<(String, String)> {
         && output.status.success()
     {
         let user = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if let Ok(output) = Command::new("sh")
-            .arg("-c")
-            .arg(format!("eval echo ~{}", user))
-            .output()
-            && output.status.success()
-        {
-            let home = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if let Some(home) = get_home_dir_for_user(&user) {
             return Ok((user, home));
         }
     }
@@ -152,24 +150,17 @@ fn execute_install_script(
         fs::set_permissions(&install_script, perms)?;
     }
 
-    let env_string: Vec<String> = env_vars
-        .iter()
-        .map(|(k, v)| format!("{}=\"{}\"", k, v.replace("\"", "\\\"")))
-        .collect();
-
-    let env_prefix = env_string.join(" ");
-    let command = format!(
-        "cd {} && {} bash -i +H -x ./{}",
+    debug!(
+        "Executing: ./{} in {} with {} env vars",
+        script_name,
         feature_dir.display(),
-        env_prefix,
-        script_name
+        env_vars.len()
     );
 
-    debug!("Executing: {}", command);
-
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(&command)
+    let output = Command::new("bash")
+        .args(["-i", "+H", "-x", &format!("./{}", script_name)])
+        .current_dir(feature_dir)
+        .envs(env_vars)
         .output()
         .context("Failed to execute install script")?;
 
@@ -219,6 +210,12 @@ fn set_container_env(feature: &Feature) -> Result<()> {
     Ok(())
 }
 
+/// Execute the feature entrypoint defined in devcontainer-feature.json.
+///
+/// TRUST BOUNDARY: The entrypoint is a shell command from the feature metadata JSON,
+/// which is downloaded from a container registry. The devcontainer spec explicitly
+/// defines entrypoints as shell commands, so shell execution here is intentional.
+/// Security relies on the caller verifying the feature source (registry + signature).
 fn execute_entrypoint(feature: &Feature) -> Result<()> {
     if let Some(entrypoint) = &feature.entrypoint {
         info!("Executing feature entrypoint: {}", entrypoint);
@@ -236,4 +233,41 @@ fn execute_entrypoint(feature: &Feature) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_home_dir_for_user_returns_none_for_nonexistent_user() {
+        // A user that almost certainly doesn't exist
+        let result = get_home_dir_for_user("__picolayer_nonexistent_test_user_12345__");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_home_dir_for_user_returns_some_for_root() {
+        // root should exist on all Unix systems
+        let result = get_home_dir_for_user("root");
+        assert!(result.is_some());
+        let home = result.unwrap();
+        assert!(!home.is_empty());
+        // root's home is typically /root but could vary
+        assert!(
+            home.starts_with('/'),
+            "Home dir should be an absolute path: {home}"
+        );
+    }
+
+    #[test]
+    fn get_home_dir_for_user_rejects_shell_metacharacters() {
+        // Even if someone passes shell metacharacters, getent treats them as literal
+        // username characters, so it will just fail to find the user (returns None)
+        let result = get_home_dir_for_user("root; echo pwned");
+        assert!(
+            result.is_none(),
+            "Shell metacharacters should not match any user"
+        );
+    }
 }

--- a/src/installers/gh_release/verifier.rs
+++ b/src/installers/gh_release/verifier.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use log::{info, warn};
+use log::info;
 use octocrab::models::repos::Asset;
 use sha2::{Digest, Sha256, Sha512};
 use std::collections::HashMap;
@@ -140,18 +140,22 @@ async fn verify_gpg_signature(
         info!("GPG signature verification passed!");
         Ok(())
     } else {
-        warn!("Found signature file but no GPG key provided");
-        info!("Use --gpg-key option to enable GPG verification");
-        Ok(())
+        anyhow::bail!(
+            "Signature file found ({}) but no GPG key provided. \
+             Use --gpg-key to provide a public key for verification.",
+            signature_asset.name
+        );
     }
 }
 
 async fn load_public_key(key_content: &str) -> Result<pgp::composed::SignedPublicKey> {
     use pgp::composed::{Deserializable, SignedPublicKey};
 
-    let key_data = if key_content.starts_with("http://") || key_content.starts_with("https://") {
+    let key_data = if key_content.starts_with("https://") {
         info!("Downloading GPG public key from URL");
         reqwest::get(key_content).await?.text().await?
+    } else if key_content.starts_with("http://") {
+        anyhow::bail!("Refusing to download GPG key over insecure HTTP. Use HTTPS instead.");
     } else if std::path::Path::new(key_content).exists() {
         tokio::fs::read_to_string(key_content).await?
     } else {
@@ -409,5 +413,33 @@ mod tests {
         assert!(patterns.contains(&"app.tar.gz.sha256".to_string()));
         assert!(patterns.contains(&"app.sha256".to_string()));
         assert!(patterns.contains(&"SHA256SUMS".to_string()));
+    }
+
+    #[test]
+    fn test_load_public_key_rejects_http() {
+        // We can't call the async function directly in a sync test,
+        // so test the URL validation logic. The function should bail on http://
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(load_public_key("http://example.com/key.asc"));
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("insecure HTTP"),
+            "Expected HTTP rejection error, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_load_public_key_accepts_non_url_as_inline_key() {
+        // Non-URL, non-file content should be treated as inline key data.
+        // It will fail to parse as a PGP key, but should NOT fail with an HTTP error.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(load_public_key("not-a-url-or-file"));
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            !err_msg.contains("insecure HTTP"),
+            "Non-URL content should not trigger HTTP rejection: {err_msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Replace `eval echo ~user` shell interpolation with `getent passwd` to eliminate command injection in devcontainer feature installer
- Use `Command` API env vars instead of shell string interpolation in `execute_install_script()`
- Reject plaintext HTTP URLs for GPG key downloads (HTTPS only)
- Return error when signature file exists but no GPG key provided (was silently bypassing verification)
- Add 5 unit tests covering injection rejection, HTTPS enforcement, and home dir resolution