### PR TITLE
refactor: use single tokio runtime via #[tokio::main]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ serde_json = "1.0"
 sha2 = "0.11.0"
 tar = "0.4.44"
 tempfile = "3.23.0"
-tokio = { version = "1.47.1", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.47.1", features = ["macros", "rt", "rt-multi-thread"] }
 walkdir = "2.5.0"
 which = "8.0.0"
 xz = "0.1.0"

--- a/src/cli/handlers.rs
+++ b/src/cli/handlers.rs
@@ -159,7 +159,7 @@ pub async fn handle_command(command: Commands, retry_config: &RetryConfig) -> Re
                 working_dir: &working_dir,
                 env_vars: env,
             };
-            installers::pkgx::execute(&config)
+            installers::pkgx::execute(&config).await
         }
     }
 }

--- a/src/cli/handlers.rs
+++ b/src/cli/handlers.rs
@@ -4,7 +4,7 @@ use crate::installers;
 use crate::utils;
 use anyhow::Result;
 
-pub fn handle_command(command: Commands, retry_config: &RetryConfig) -> Result<()> {
+pub async fn handle_command(command: Commands, retry_config: &RetryConfig) -> Result<()> {
     match command {
         Commands::AptGet { packages, ppa_args } => {
             anyhow::ensure!(
@@ -107,11 +107,7 @@ pub fn handle_command(command: Commands, retry_config: &RetryConfig) -> Result<(
                 registry_token: registry_token.as_deref(),
             };
 
-            let rt = tokio::runtime::Runtime::new()?;
-            rt.block_on(installers::devcontainer_feature::install_async(
-                &config,
-                retry_config,
-            ))
+            installers::devcontainer_feature::install_async(&config, retry_config).await
         }
 
         Commands::GhRelease {
@@ -132,8 +128,7 @@ pub fn handle_command(command: Commands, retry_config: &RetryConfig) -> Result<(
             );
             let binary_list = normalize_package_list(&binary.unwrap_or_else(|| repo.clone()));
 
-            let rt = tokio::runtime::Runtime::new()?;
-            rt.block_on(installers::gh_release::install(
+            installers::gh_release::install(
                 &installers::gh_release::GhReleaseConfig {
                     owner: &owner,
                     repo: &repo,
@@ -147,7 +142,8 @@ pub fn handle_command(command: Commands, retry_config: &RetryConfig) -> Result<(
                     include_prerelease,
                 },
                 retry_config,
-            ))
+            )
+            .await
         }
         Commands::Pkgx {
             tool,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,8 +6,8 @@ use clap::Parser;
 
 pub use args::{Cli, RetryConfig};
 
-pub fn run() -> Result<()> {
+pub async fn run() -> Result<()> {
     let cli = Cli::parse();
     let retry_config = args::RetryConfig::from_cli(&cli);
-    handlers::handle_command(cli.command, &retry_config)
+    handlers::handle_command(cli.command, &retry_config).await
 }

--- a/src/installers/pkgx/mod.rs
+++ b/src/installers/pkgx/mod.rs
@@ -45,7 +45,7 @@ impl PkgxEnv {
     }
 }
 
-pub fn execute(input: &PkgxConfig) -> Result<()> {
+pub async fn execute(input: &PkgxConfig<'_>) -> Result<()> {
     validate_working_directory(input.working_dir)?;
     debug!("Working directory: {}", input.working_dir);
     debug!("Tool: {} ({})", input.tool, input.version);
@@ -76,7 +76,8 @@ pub fn execute(input: &PkgxConfig) -> Result<()> {
         working_path,
         &env_map,
         &exec_env,
-    );
+    )
+    .await;
 
     // Restore original environment variables
     unsafe {
@@ -137,7 +138,7 @@ fn create_command_env(
     cmd_env
 }
 
-fn execute_with_pkgx_library(
+async fn execute_with_pkgx_library(
     tool_name: &str,
     version_spec: &str,
     args: &[String],
@@ -148,12 +149,13 @@ fn execute_with_pkgx_library(
     info!("Using pkgx library integration with virtual environment");
 
     let project_name = resolver::resolve_tool_to_project(tool_name)
+        .await
         .context("Failed to resolve tool to project using pkgx")?;
 
     let tool_spec = resolver::format_tool_spec(&project_name, version_spec);
     info!("Resolving package: {}", tool_spec);
 
-    match resolver::resolve_package_with_libpkgx(&[tool_spec]) {
+    match resolver::resolve_package_with_libpkgx(&[tool_spec]).await {
         Ok((pkgx_env, installations)) => {
             let mut cmd_env = create_command_env(env_map, &exec_env.pkgx_dir, &exec_env.pantry_dir);
             cmd_env.extend(pkgx_env);
@@ -191,6 +193,7 @@ fn execute_with_pkgx_library(
                     env_map,
                     exec_env,
                 )
+                .await
             } else {
                 anyhow::bail!(
                     "Failed to resolve package with libpkgx and no pkgx binary available: {}",
@@ -221,7 +224,7 @@ fn log_installations(
     }
 }
 
-fn execute_with_pkgx_binary(
+async fn execute_with_pkgx_binary(
     tool_name: &str,
     version_spec: &str,
     args: &[String],
@@ -234,6 +237,7 @@ fn execute_with_pkgx_binary(
     }
 
     let project_name = resolver::resolve_tool_to_project(tool_name)
+        .await
         .context("Failed to resolve tool to project using pkgx")?;
 
     let project_arg = resolver::format_project_arg(&project_name, version_spec);

--- a/src/installers/pkgx/resolver.rs
+++ b/src/installers/pkgx/resolver.rs
@@ -8,13 +8,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Resolve package dependencies using libpkgx
-pub(super) fn resolve_package_with_libpkgx(
+pub(super) async fn resolve_package_with_libpkgx(
     dependencies: &[String],
 ) -> Result<(HashMap<String, String>, Vec<libpkgx::types::Installation>)> {
-    let rt = tokio::runtime::Runtime::new()
-        .context("Failed to create Tokio runtime for libpkgx operations")?;
-
-    rt.block_on(async { resolve_dependencies_async(dependencies).await })
+    resolve_dependencies_async(dependencies).await
 }
 
 async fn resolve_dependencies_async(
@@ -150,7 +147,7 @@ fn map_tool_to_project(tool_name: &str, conn: &rusqlite::Connection) -> Result<S
 }
 
 /// Resolve a tool name to a project name
-pub(super) fn resolve_tool_to_project(tool_name: &str) -> Result<String> {
+pub(super) async fn resolve_tool_to_project(tool_name: &str) -> Result<String> {
     assert!(std::env::var("PKGX_DIR").is_ok());
     assert!(std::env::var("PKGX_PANTRY_DIR").is_ok());
     let config = Config::new().context("Failed to initialize libpkgx config")?;
@@ -160,13 +157,9 @@ pub(super) fn resolve_tool_to_project(tool_name: &str) -> Result<String> {
     // Sync if needed
     if sync::should(&config).map_err(|e| anyhow::anyhow!("{}", e))? {
         info!("Syncing pkgx pantry database");
-        let rt =
-            tokio::runtime::Runtime::new().context("Failed to create Tokio runtime for sync")?;
-        rt.block_on(async {
-            sync::ensure(&config, &mut conn)
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))
-        })?;
+        sync::ensure(&config, &mut conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
     }
 
     map_tool_to_project(tool_name, &conn)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,21 +8,22 @@ use error::PicolayerError;
 use log::info;
 use std::process;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("Failed to install default CryptoProvider");
 
-    if let Err(e) = run() {
+    if let Err(e) = run().await {
         let picolayer_error: PicolayerError = e.into();
         eprintln!("{}", picolayer_error);
         process::exit(1);
     }
 }
 
-fn run() -> Result<()> {
+async fn run() -> Result<()> {
     utils::logging::init_logging().context("Failed to initialize logging")?;
     info!("Starting picolayer");
-    cli::run()?;
+    cli::run().await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace per-handler `Runtime::new()` + `block_on()` with single `#[tokio::main]` runtime
- Make CLI chain async: `main()` → `run()` → `cli::run()` → `handle_command()`
- Add `macros` feature to tokio dependency for `#[tokio::main]`
- Remove 2 redundant runtime instantiations in devcontainer-feature and gh-release handlers