### PR TITLE
refactor: tighten pub visibility across all modules

### DIFF
--- a/src/installers/devcontainer_feature/client.rs
+++ b/src/installers/devcontainer_feature/client.rs
@@ -8,7 +8,7 @@ use crate::cli::RetryConfig;
 use crate::utils::retry::retry_async;
 
 /// Download and extract OCI layer
-pub async fn download_and_extract_layer(
+pub(super) async fn download_and_extract_layer(
     feature_ref: &str,
     output_dir: &Path,
     username: Option<&str>,

--- a/src/installers/devcontainer_feature/feature.rs
+++ b/src/installers/devcontainer_feature/feature.rs
@@ -4,27 +4,27 @@ use std::collections::HashMap;
 /// DevContainer Feature metadata
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Feature {
-    pub id: String,
-    pub version: Option<String>,
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub options: Option<HashMap<String, FeatureOption>>,
-    pub container_env: Option<HashMap<String, String>>,
-    pub entrypoint: Option<String>,
+pub(super) struct Feature {
+    pub(super) id: String,
+    pub(super) version: Option<String>,
+    pub(super) name: Option<String>,
+    pub(super) description: Option<String>,
+    pub(super) options: Option<HashMap<String, FeatureOption>>,
+    pub(super) container_env: Option<HashMap<String, String>>,
+    pub(super) entrypoint: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FeatureOption {
+pub(super) struct FeatureOption {
     #[serde(rename = "type")]
-    pub option_type: String,
-    pub default: Option<serde_json::Value>,
-    pub description: Option<String>,
+    pub(super) option_type: String,
+    pub(super) default: Option<serde_json::Value>,
+    pub(super) description: Option<String>,
 }
 
 impl Feature {
     /// Resolve feature options with defaults
-    pub fn resolve_options(
+    pub(super) fn resolve_options(
         &self,
         provided_options: Option<HashMap<String, String>>,
     ) -> HashMap<String, String> {

--- a/src/installers/devcontainer_feature/installer.rs
+++ b/src/installers/devcontainer_feature/installer.rs
@@ -10,7 +10,7 @@ use super::{DevcontainerFeatureConfig, client};
 
 const ORDERED_BASE_USERS: &[&str] = &["vscode", "node", "codespace"];
 
-pub async fn install_async(
+pub(super) async fn install_async(
     config: &DevcontainerFeatureConfig<'_>,
     retry_config: &crate::cli::RetryConfig,
 ) -> Result<()> {

--- a/src/installers/gh_release/client.rs
+++ b/src/installers/gh_release/client.rs
@@ -5,7 +5,7 @@ use octocrab::models::repos::Release;
 use crate::cli::RetryConfig;
 use crate::utils::retry::retry_async;
 
-pub async fn fetch_release(
+pub(super) async fn fetch_release(
     owner: &str,
     repo: &str,
     version: &str,

--- a/src/installers/gh_release/extractor.rs
+++ b/src/installers/gh_release/extractor.rs
@@ -5,13 +5,13 @@ use std::fs::{self, File};
 use std::io::{BufReader, Write};
 use std::path::Path;
 
-pub enum AssetExtractor {
+enum AssetExtractor {
     Archive,
     RawBinary,
 }
 
 impl AssetExtractor {
-    pub async fn extract(
+    async fn extract(
         &self,
         asset: &Asset,
         binary_names: &[String],
@@ -37,7 +37,7 @@ impl AssetExtractor {
     }
 }
 
-pub fn create_extractor(asset: &Asset) -> AssetExtractor {
+fn create_extractor(asset: &Asset) -> AssetExtractor {
     if is_archive(&asset.name.to_lowercase()) {
         AssetExtractor::Archive
     } else {
@@ -45,7 +45,7 @@ pub fn create_extractor(asset: &Asset) -> AssetExtractor {
     }
 }
 
-pub async fn extract_and_install(
+pub(super) async fn extract_and_install(
     asset: &Asset,
     binary_names: &[String],
     bin_location: &str,

--- a/src/installers/gh_release/selector.rs
+++ b/src/installers/gh_release/selector.rs
@@ -2,16 +2,16 @@ use anyhow::{Context, Result};
 use octocrab::models::repos::Asset;
 use regex::Regex;
 
-pub trait AssetSelector {
+pub(super) trait AssetSelector {
     fn select<'a>(&self, assets: &'a [Asset]) -> Result<&'a Asset>;
 }
 
-pub struct FilterSelector {
+struct FilterSelector {
     regex: Regex,
 }
 
 impl FilterSelector {
-    pub fn new(pattern: &str) -> Result<Self> {
+    fn new(pattern: &str) -> Result<Self> {
         let regex = Regex::new(pattern).context("Invalid filter pattern")?;
         Ok(Self { regex })
     }
@@ -26,7 +26,7 @@ impl AssetSelector for FilterSelector {
     }
 }
 
-pub struct PlatformSelector;
+struct PlatformSelector;
 
 impl AssetSelector for PlatformSelector {
     fn select<'a>(&self, assets: &'a [Asset]) -> Result<&'a Asset> {
@@ -36,7 +36,7 @@ impl AssetSelector for PlatformSelector {
     }
 }
 
-pub fn create_selector(filter: Option<&str>) -> Result<Box<dyn AssetSelector>> {
+pub(super) fn create_selector(filter: Option<&str>) -> Result<Box<dyn AssetSelector>> {
     match filter {
         Some(pattern) => Ok(Box::new(FilterSelector::new(pattern)?)),
         None => Ok(Box::new(PlatformSelector)),

--- a/src/installers/gh_release/verifier.rs
+++ b/src/installers/gh_release/verifier.rs
@@ -4,7 +4,7 @@ use octocrab::models::repos::Asset;
 use sha2::{Digest, Sha256, Sha512};
 use std::collections::HashMap;
 
-pub async fn verify_with_checksum_text(asset: &Asset, checksum_text: &str) -> Result<()> {
+pub(super) async fn verify_with_checksum_text(asset: &Asset, checksum_text: &str) -> Result<()> {
     info!("Verifying asset with provided checksum text");
 
     let (algorithm, expected_hash) = parse_checksum_text(checksum_text)?;
@@ -23,7 +23,11 @@ pub async fn verify_with_checksum_text(asset: &Asset, checksum_text: &str) -> Re
     }
 }
 
-pub async fn verify_asset(assets: &[Asset], asset: &Asset, gpg_key: Option<&str>) -> Result<()> {
+pub(super) async fn verify_asset(
+    assets: &[Asset],
+    asset: &Asset,
+    gpg_key: Option<&str>,
+) -> Result<()> {
     info!("Verifying asset");
 
     if let Some(sig_asset) = find_signature_asset(assets, asset) {

--- a/src/installers/package_manager/apk.rs
+++ b/src/installers/package_manager/apk.rs
@@ -2,7 +2,7 @@ use crate::utils;
 use anyhow::{Context, Result};
 use log::info;
 
-pub fn install(packages: &[String]) -> Result<()> {
+pub(super) fn install(packages: &[String]) -> Result<()> {
     if std::process::Command::new("which")
         .arg("apk")
         .output()

--- a/src/installers/package_manager/apt_based.rs
+++ b/src/installers/package_manager/apt_based.rs
@@ -7,7 +7,7 @@ use super::PackageManagerConfig;
 const PPA_SUPPORT_PACKAGES: &[&str] = &["software-properties-common"];
 const PPA_SUPPORT_PACKAGES_DEBIAN: &[&str] = &["python3-launchpadlib"];
 
-pub fn install(tool: &str, config: &PackageManagerConfig) -> Result<()> {
+pub(super) fn install(tool: &str, config: &PackageManagerConfig) -> Result<()> {
     anyhow::ensure!(
         which::which(tool).is_ok(),
         "{} command not found in PATH",
@@ -35,7 +35,7 @@ pub fn install(tool: &str, config: &PackageManagerConfig) -> Result<()> {
     Ok(())
 }
 
-pub fn install_aptitude(packages: &[String]) -> Result<()> {
+pub(super) fn install_aptitude(packages: &[String]) -> Result<()> {
     update_repositories()?;
     install_aptitude_tool()?;
     install_packages_aptitude(packages)?;

--- a/src/installers/package_manager/brew.rs
+++ b/src/installers/package_manager/brew.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use log::info;
 
-pub fn install(packages: &[String]) -> Result<()> {
+pub(super) fn install(packages: &[String]) -> Result<()> {
     anyhow::ensure!(
         which::which("brew").is_ok(),
         "Homebrew not installed or not in PATH"

--- a/src/installers/pkgx/resolver.rs
+++ b/src/installers/pkgx/resolver.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Resolve package dependencies using libpkgx
-pub fn resolve_package_with_libpkgx(
+pub(super) fn resolve_package_with_libpkgx(
     dependencies: &[String],
 ) -> Result<(HashMap<String, String>, Vec<libpkgx::types::Installation>)> {
     let rt = tokio::runtime::Runtime::new()
@@ -118,7 +118,7 @@ async fn resolve_dependencies_async(
 }
 
 /// Query the pkgx pantry database to resolve a tool name to a project name
-pub fn map_tool_to_project(tool_name: &str, conn: &rusqlite::Connection) -> Result<String> {
+fn map_tool_to_project(tool_name: &str, conn: &rusqlite::Connection) -> Result<String> {
     let tool_name_string = tool_name.to_string();
     match libpkgx::pantry_db::projects_for_symbol(&tool_name_string, conn) {
         Ok(projects) if !projects.is_empty() => {
@@ -150,7 +150,7 @@ pub fn map_tool_to_project(tool_name: &str, conn: &rusqlite::Connection) -> Resu
 }
 
 /// Resolve a tool name to a project name
-pub fn resolve_tool_to_project(tool_name: &str) -> Result<String> {
+pub(super) fn resolve_tool_to_project(tool_name: &str) -> Result<String> {
     assert!(std::env::var("PKGX_DIR").is_ok());
     assert!(std::env::var("PKGX_PANTRY_DIR").is_ok());
     let config = Config::new().context("Failed to initialize libpkgx config")?;
@@ -173,7 +173,7 @@ pub fn resolve_tool_to_project(tool_name: &str) -> Result<String> {
 }
 
 /// Format tool spec for libpkgx (without + prefix)
-pub fn format_tool_spec(project_name: &str, version_spec: &str) -> String {
+pub(super) fn format_tool_spec(project_name: &str, version_spec: &str) -> String {
     if version_spec == "latest" {
         project_name.to_string()
     } else {
@@ -182,7 +182,7 @@ pub fn format_tool_spec(project_name: &str, version_spec: &str) -> String {
 }
 
 /// Format project arg for pkgx binary (with + prefix)
-pub fn format_project_arg(project_name: &str, version_spec: &str) -> String {
+pub(super) fn format_project_arg(project_name: &str, version_spec: &str) -> String {
     if version_spec == "latest" {
         format!("+{}", project_name)
     } else {
@@ -191,7 +191,7 @@ pub fn format_project_arg(project_name: &str, version_spec: &str) -> String {
 }
 
 /// Check if the pkgx binary is available on the system
-pub fn check_pkgx_binary() -> bool {
+pub(super) fn check_pkgx_binary() -> bool {
     use std::process::{Command, Stdio};
 
     Command::new("pkgx")


### PR DESCRIPTION
## Summary
- Narrow 25+ `pub` items to minimum required visibility (`pub(super)`, `pub(crate)`, or private)
- Internal types like `FilterSelector`, `PlatformSelector`, `AssetExtractor` made private
- Module-internal functions narrowed across gh_release, pkgx, package_manager, devcontainer_feature
- 11 files modified, no functional changes