### PR TITLE
ci: pin third-party actions to SHA, harden permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_LOG: ${{ vars.RUST_LOG || 'info' }}
@@ -49,7 +52,6 @@ jobs:
           os: linux
 
   alpine-build:
-    needs: linux-build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -59,7 +61,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Alpine Linux ${{ matrix.alpine-version }}
-        uses: jirutka/setup-alpine@v1
+        uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1
         with:
           arch: x86_64
           branch: ${{ matrix.alpine-version }}
@@ -128,7 +130,6 @@ jobs:
           os: alpine
 
   macos-build:
-    needs: alpine-build
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -28,6 +28,6 @@ jobs:
         with:
           node-version: "latest"
 
-      - uses: devcontainers/ci@v0.3
+      - uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5 # v0.3
         with:
           runCmd: ${{ inputs.runCmd || env.DEFAULT_RUN_CMD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -42,7 +42,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           push: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,14 @@ jobs:
   megalinter:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
 
       - name: megalinter
-        uses: oxsecurity/megalinter@v9
+        uses: oxsecurity/megalinter@8fbdead70d1409964ab3d5afa885e18ee85388bb # v9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: biomejs/setup-biome@v2
+      - uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       new-release-version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
       - name: bitwarden secrets
-        uses: bitwarden/sm-action@v3.0.0
+        uses: bitwarden/sm-action@27c0c9dcab679d7250dbab91227c85b49ffa5e0f # v3.0.0
         with:
           access_token: ${{ secrets.BITWARDEN_SECRETS_ACCESS_TOKEN }}
           secrets: |
@@ -32,7 +32,7 @@ jobs:
           token: ${{ env.WORKFLOWS_PAT }}
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -40,7 +40,7 @@ jobs:
           git_commit_gpgsign: true
 
       - id: semantic
-        uses: cycjimmy/semantic-release-action@v6
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
         with:
           extra_plugins: |
             @semantic-release/exec
@@ -117,7 +117,7 @@ jobs:
           path: artifacts
 
       - name: Upload binaries to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: v${{ needs.semantic-release.outputs.new-release-version }}
           files: artifacts/*/picolayer-*.tar.gz

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,21 +11,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: bitwarden/sm-action@v3.0.0
+      - uses: bitwarden/sm-action@27c0c9dcab679d7250dbab91227c85b49ffa5e0f # v3.0.0
         with:
           access_token: ${{ secrets.BITWARDEN_SECRETS_ACCESS_TOKEN }}
           secrets: |
             ${{ secrets.RENOVATE_TOKEN_UUID }} > RENOVATE_TOKEN
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - uses: renovatebot/github-action@v46.1.9
+      - uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
         with:
           token: ${{ env.RENOVATE_TOKEN }}
         env:


### PR DESCRIPTION
## Summary
- Pin 13 third-party GitHub Actions to commit SHA digests (with version comments)
- Minimize permissions: set `contents: read` on ci.yml and lint.yml
- Parallelize CI build jobs by removing unnecessary `needs:` chains