### PR TITLE
test: expand unit test coverage for utils and error modules

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -90,3 +90,81 @@ impl From<anyhow::Error> for PicolayerError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_anyhow_classifies_github_not_found() {
+        let err = anyhow::anyhow!("GitHub API returned Not Found");
+        let picolayer_err: PicolayerError = err.into();
+        assert!(matches!(picolayer_err, PicolayerError::RepositoryNotFound));
+    }
+
+    #[test]
+    fn from_anyhow_classifies_oci_pull_failure() {
+        let err = anyhow::anyhow!("Failed to pull OCI image");
+        let picolayer_err: PicolayerError = err.into();
+        assert!(matches!(
+            picolayer_err,
+            PicolayerError::ContainerFeatureDownloadFailed
+        ));
+    }
+
+    #[test]
+    fn from_anyhow_classifies_no_matching_assets() {
+        let err = anyhow::anyhow!("No matching release found");
+        let picolayer_err: PicolayerError = err.into();
+        assert!(matches!(picolayer_err, PicolayerError::NoMatchingAssets));
+    }
+
+    #[test]
+    fn from_anyhow_classifies_permission_denied() {
+        let err = anyhow::anyhow!("Permission denied writing to /usr/local/bin");
+        let picolayer_err: PicolayerError = err.into();
+        assert!(matches!(picolayer_err, PicolayerError::PermissionDenied));
+    }
+
+    #[test]
+    fn from_anyhow_classifies_disk_space() {
+        let err = anyhow::anyhow!("No space left on device");
+        let picolayer_err: PicolayerError = err.into();
+        assert!(matches!(
+            picolayer_err,
+            PicolayerError::InsufficientDiskSpace
+        ));
+    }
+
+    #[test]
+    fn from_anyhow_classifies_network_error() {
+        let err = anyhow::anyhow!("Network connection refused");
+        let picolayer_err: PicolayerError = err.into();
+        assert!(matches!(
+            picolayer_err,
+            PicolayerError::NetworkConnectionFailed
+        ));
+    }
+
+    #[test]
+    fn from_anyhow_falls_through_to_catch_all() {
+        let err = anyhow::anyhow!("Some completely unknown error");
+        let picolayer_err: PicolayerError = err.into();
+        assert!(matches!(picolayer_err, PicolayerError::CatchAll(_)));
+    }
+
+    #[test]
+    fn display_includes_helpful_message() {
+        let err = PicolayerError::RepositoryNotFound;
+        let display = format!("{}", err);
+        assert!(display.contains("Repository not found"));
+        assert!(display.contains("Check the owner/repo names"));
+    }
+
+    #[test]
+    fn display_catch_all_includes_error_message() {
+        let err = PicolayerError::CatchAll(anyhow::anyhow!("test error message"));
+        let display = format!("{}", err);
+        assert!(display.contains("test error message"));
+    }
+}

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -47,3 +47,88 @@ fn setup_file_logging(builder: &mut env_logger::Builder, log_file_path: &str) ->
     builder.target(env_logger::Target::Pipe(Box::new(file)));
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use log::LevelFilter;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn get_log_level_defaults_to_warn() {
+        // Clear relevant env vars
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::remove_var("PICOLAYER_LOG_LEVEL");
+            std::env::remove_var("RUST_LOG");
+        }
+        assert_eq!(get_log_level(), LevelFilter::Warn);
+    }
+
+    #[test]
+    #[serial]
+    fn get_log_level_respects_picolayer_env() {
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::set_var("PICOLAYER_LOG_LEVEL", "debug");
+            std::env::remove_var("RUST_LOG");
+        }
+        let level = get_log_level();
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::remove_var("PICOLAYER_LOG_LEVEL");
+        }
+        assert_eq!(level, LevelFilter::Debug);
+    }
+
+    #[test]
+    #[serial]
+    fn get_log_level_picolayer_overrides_rust_log() {
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::set_var("PICOLAYER_LOG_LEVEL", "error");
+            std::env::set_var("RUST_LOG", "info");
+        }
+        let level = get_log_level();
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::remove_var("PICOLAYER_LOG_LEVEL");
+            std::env::remove_var("RUST_LOG");
+        }
+        assert_eq!(level, LevelFilter::Error);
+    }
+
+    #[test]
+    #[serial]
+    fn get_log_level_falls_back_to_rust_log() {
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::remove_var("PICOLAYER_LOG_LEVEL");
+            std::env::set_var("RUST_LOG", "info");
+        }
+        let level = get_log_level();
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::remove_var("RUST_LOG");
+        }
+        assert_eq!(level, LevelFilter::Info);
+    }
+
+    #[test]
+    #[serial]
+    fn get_log_level_ignores_invalid_values() {
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::set_var("PICOLAYER_LOG_LEVEL", "not_a_level");
+            std::env::remove_var("RUST_LOG");
+        }
+        let level = get_log_level();
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::remove_var("PICOLAYER_LOG_LEVEL");
+        }
+        // Falls through to default when parse fails
+        assert_eq!(level, LevelFilter::Warn);
+    }
+}

--- a/src/utils/os.rs
+++ b/src/utils/os.rs
@@ -111,3 +111,62 @@ pub fn is_macos() -> bool {
 pub fn is_linux() -> bool {
     std::env::consts::OS == "linux"
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_distro_returns_valid_variant() {
+        // Should return some valid distro, never panic
+        let result = detect_distro();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn is_macos_matches_platform() {
+        if cfg!(target_os = "macos") {
+            assert!(is_macos());
+        } else {
+            assert!(!is_macos());
+        }
+    }
+
+    #[test]
+    fn is_linux_matches_platform() {
+        if cfg!(target_os = "linux") {
+            assert!(is_linux());
+        } else {
+            assert!(!is_linux());
+        }
+    }
+
+    #[test]
+    fn linux_distro_enum_debug() {
+        // Ensure Debug derive works
+        let distro = LinuxDistro::Ubuntu;
+        assert_eq!(format!("{:?}", distro), "Ubuntu");
+    }
+
+    #[test]
+    fn linux_distro_enum_eq() {
+        // Ensure PartialEq works
+        assert_eq!(LinuxDistro::Ubuntu, LinuxDistro::Ubuntu);
+        assert_ne!(LinuxDistro::Ubuntu, LinuxDistro::Debian);
+        assert_ne!(LinuxDistro::Alpine, LinuxDistro::Other);
+    }
+
+    #[test]
+    fn debian_like_includes_ubuntu_and_debian() {
+        // On this system, verify consistency between functions
+        if is_ubuntu() {
+            assert!(is_debian_like());
+        }
+        if is_debian() {
+            assert!(is_debian_like());
+        }
+        if is_alpine() {
+            assert!(!is_debian_like());
+        }
+    }
+}

--- a/src/utils/retry.rs
+++ b/src/utils/retry.rs
@@ -56,3 +56,68 @@ where
 
     Err(last_error.unwrap())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn test_config(max_retries: u32) -> RetryConfig {
+        RetryConfig {
+            max_retries,
+            initial_delay_ms: 1, // 1ms for fast tests
+            backoff_multiplier: 1.0,
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_succeeds_on_first_attempt() {
+        let result = retry_async(&test_config(3), "test", || async {
+            Ok::<_, anyhow::Error>(42)
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn retry_succeeds_after_failures() {
+        let attempts = AtomicU32::new(0);
+        let result = retry_async(&test_config(3), "test", || {
+            let count = attempts.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if count < 2 {
+                    Err(anyhow::anyhow!("transient failure"))
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3); // 2 failures + 1 success
+    }
+
+    #[tokio::test]
+    async fn retry_exhausts_all_attempts() {
+        let attempts = AtomicU32::new(0);
+        let result: Result<i32> = retry_async(&test_config(2), "test", || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            async { Err(anyhow::anyhow!("persistent failure")) }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(attempts.load(Ordering::SeqCst), 3); // initial + 2 retries
+    }
+
+    #[tokio::test]
+    async fn retry_zero_retries_runs_once() {
+        let attempts = AtomicU32::new(0);
+        let result: Result<i32> = retry_async(&test_config(0), "test", || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            async { Err(anyhow::anyhow!("failure")) }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
## Summary
Add 24 unit tests across 4 previously untested modules:
- `error.rs`: 9 tests for error classification (`From<anyhow::Error>`) and `Display` impl
- `utils/retry.rs`: 4 async tests for retry logic, backoff, and attempt counting
- `utils/os.rs`: 6 tests for platform detection and `LinuxDistro` enum
- `utils/logging.rs`: 5 tests for log level env var precedence (serialized with `#[serial]`)