### PR TITLE
fix: gate getent-dependent test to Linux only

### DIFF
--- a/src/installers/devcontainer_feature/installer.rs
+++ b/src/installers/devcontainer_feature/installer.rs
@@ -247,8 +247,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn get_home_dir_for_user_returns_some_for_root() {
-        // root should exist on all Unix systems
+        // root should exist on all Linux systems; getent is not available on macOS
         let result = get_home_dir_for_user("root");
         assert!(result.is_some());
         let home = result.unwrap();


### PR DESCRIPTION
## Summary
- The `get_home_dir_for_user_returns_some_for_root` test uses `getent passwd` which is not available on macOS, causing `macos-build (x86_64-apple-darwin)` CI failures
- Gates the test with `#[cfg(target_os = "linux")]` since the devcontainer feature installer is already Linux-only