### PR TITLE
fix: correct log levels for expected fallbacks

### DIFF
--- a/src/installers/gh_release/extractor.rs
+++ b/src/installers/gh_release/extractor.rs
@@ -311,7 +311,7 @@ fn find_and_install_binaries(
             if binary_names.iter().any(|name| name == &file_name) {
                 // Skip zero-byte files
                 if entry.metadata()?.len() == 0 {
-                    log::warn!("Skipping zero-byte file: {}", file_name);
+                    log::debug!("Skipping zero-byte file: {}", file_name);
                     continue;
                 }
 

--- a/src/installers/package_manager/apt_based.rs
+++ b/src/installers/package_manager/apt_based.rs
@@ -16,8 +16,7 @@ pub(super) fn install(tool: &str, config: &PackageManagerConfig) -> Result<()> {
 
     let mut ppas = config.ppas.map(|p| p.to_vec()).unwrap_or_default();
     if !ppas.is_empty() && !utils::os::is_ubuntu() && !config.force_ppas_on_non_ubuntu {
-        warn!("PPAs are ignored on non-Ubuntu distros!");
-        info!("Use --force-ppas-on-non-ubuntu to include them anyway.");
+        warn!("PPAs are ignored on non-Ubuntu distros. Use --force-ppas-on-non-ubuntu to include them anyway.");
         ppas.clear();
     }
 

--- a/src/installers/package_manager/apt_based.rs
+++ b/src/installers/package_manager/apt_based.rs
@@ -16,7 +16,9 @@ pub(super) fn install(tool: &str, config: &PackageManagerConfig) -> Result<()> {
 
     let mut ppas = config.ppas.map(|p| p.to_vec()).unwrap_or_default();
     if !ppas.is_empty() && !utils::os::is_ubuntu() && !config.force_ppas_on_non_ubuntu {
-        warn!("PPAs are ignored on non-Ubuntu distros. Use --force-ppas-on-non-ubuntu to include them anyway.");
+        warn!(
+            "PPAs are ignored on non-Ubuntu distros. Use --force-ppas-on-non-ubuntu to include them anyway."
+        );
         ppas.clear();
     }
 

--- a/src/installers/pkgx/resolver.rs
+++ b/src/installers/pkgx/resolver.rs
@@ -3,7 +3,7 @@ use libpkgx::config::Config;
 use libpkgx::{
     hydrate, install_multi::ProgressBarExt, pantry_db, resolve, sync, types::PackageReq,
 };
-use log::{info, warn};
+use log::{debug, info, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -65,7 +65,7 @@ async fn resolve_dependencies_async(
         match PackageReq::parse(dep) {
             Ok(req) => package_reqs.push(req),
             Err(e) => {
-                eprintln!("Warning: Failed to parse dependency {}: {}", dep, e);
+                warn!("Failed to parse dependency {}: {}", dep, e);
                 continue;
             }
         }
@@ -130,14 +130,14 @@ fn map_tool_to_project(tool_name: &str, conn: &rusqlite::Connection) -> Result<S
             }
         }
         Ok(_) => {
-            warn!(
+            debug!(
                 "No project found for tool '{}' in pantry database, using tool name as project",
                 tool_name
             );
             Ok(tool_name.to_string())
         }
         Err(e) => {
-            warn!(
+            debug!(
                 "Failed to query pantry database for tool '{}': {}, using tool name as project",
                 tool_name, e
             );


### PR DESCRIPTION
## Summary
- Replace `eprintln!` with `warn!()` in pkgx resolver for consistent logging
- Downgrade expected fallback messages from `warn!` to `debug!` in resolver (pantry DB miss) and extractor (zero-byte file skip)
- Fold separate `warn!` + `info!` into single `warn!` for PPA hint in apt_based