### PR TITLE
feat: add -v/--verbose and -q/--quiet CLI flags

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -38,6 +38,14 @@ pub struct Cli {
     /// Multiplier for exponential backoff (default: 2.0)
     #[arg(long, global = true, default_value = "2.0")]
     pub retry_backoff_multiplier: f64,
+
+    /// Increase logging verbosity (-v for info, -vv for debug, -vvv for trace)
+    #[arg(short = 'v', long = "verbose", global = true, action = clap::ArgAction::Count)]
+    pub verbose: u8,
+
+    /// Suppress all output except errors
+    #[arg(short = 'q', long = "quiet", global = true, conflicts_with = "verbose")]
+    pub quiet: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,12 +2,10 @@ mod args;
 mod handlers;
 
 use anyhow::Result;
-use clap::Parser;
 
 pub use args::{Cli, RetryConfig};
 
-pub async fn run() -> Result<()> {
-    let cli = Cli::parse();
+pub async fn run(cli: Cli) -> Result<()> {
     let retry_config = args::RetryConfig::from_cli(&cli);
     handlers::handle_command(cli.command, &retry_config).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod installers;
 mod utils;
 
 use anyhow::{Context, Result};
+use clap::Parser;
 use error::PicolayerError;
 use log::info;
 use std::process;
@@ -22,8 +23,9 @@ async fn main() {
 }
 
 async fn run() -> Result<()> {
-    utils::logging::init_logging().context("Failed to initialize logging")?;
+    let cli = cli::Cli::parse();
+    utils::logging::init_logging(cli.verbose, cli.quiet).context("Failed to initialize logging")?;
     info!("Starting picolayer");
-    cli::run().await?;
+    cli::run(cli).await?;
     Ok(())
 }

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -3,9 +3,9 @@ use log::LevelFilter;
 use std::fs;
 use std::path::PathBuf;
 
-pub fn init_logging() -> Result<()> {
+pub fn init_logging(verbose: u8, quiet: bool) -> Result<()> {
     let mut builder = env_logger::Builder::new();
-    builder.filter_level(get_log_level());
+    builder.filter_level(get_log_level(verbose, quiet));
 
     if let Ok(log_file_path) = std::env::var("PICOLAYER_LOG_FILE")
         && !log_file_path.is_empty()
@@ -17,7 +17,20 @@ pub fn init_logging() -> Result<()> {
     Ok(())
 }
 
-fn get_log_level() -> LevelFilter {
+fn get_log_level(verbose: u8, quiet: bool) -> LevelFilter {
+    // CLI flags take precedence
+    if quiet {
+        return LevelFilter::Error;
+    }
+    if verbose > 0 {
+        return match verbose {
+            1 => LevelFilter::Info,
+            2 => LevelFilter::Debug,
+            _ => LevelFilter::Trace,
+        };
+    }
+
+    // Fall back to env vars
     if let Ok(level_str) = std::env::var("PICOLAYER_LOG_LEVEL")
         && let Ok(level) = level_str.parse()
     {
@@ -63,7 +76,7 @@ mod tests {
             std::env::remove_var("PICOLAYER_LOG_LEVEL");
             std::env::remove_var("RUST_LOG");
         }
-        assert_eq!(get_log_level(), LevelFilter::Warn);
+        assert_eq!(get_log_level(0, false), LevelFilter::Warn);
     }
 
     #[test]
@@ -74,7 +87,7 @@ mod tests {
             std::env::set_var("PICOLAYER_LOG_LEVEL", "debug");
             std::env::remove_var("RUST_LOG");
         }
-        let level = get_log_level();
+        let level = get_log_level(0, false);
         // SAFETY: serialized via #[serial] so no concurrent env access
         unsafe {
             std::env::remove_var("PICOLAYER_LOG_LEVEL");
@@ -90,7 +103,7 @@ mod tests {
             std::env::set_var("PICOLAYER_LOG_LEVEL", "error");
             std::env::set_var("RUST_LOG", "info");
         }
-        let level = get_log_level();
+        let level = get_log_level(0, false);
         // SAFETY: serialized via #[serial] so no concurrent env access
         unsafe {
             std::env::remove_var("PICOLAYER_LOG_LEVEL");
@@ -107,7 +120,7 @@ mod tests {
             std::env::remove_var("PICOLAYER_LOG_LEVEL");
             std::env::set_var("RUST_LOG", "info");
         }
-        let level = get_log_level();
+        let level = get_log_level(0, false);
         // SAFETY: serialized via #[serial] so no concurrent env access
         unsafe {
             std::env::remove_var("RUST_LOG");
@@ -123,12 +136,46 @@ mod tests {
             std::env::set_var("PICOLAYER_LOG_LEVEL", "not_a_level");
             std::env::remove_var("RUST_LOG");
         }
-        let level = get_log_level();
+        let level = get_log_level(0, false);
         // SAFETY: serialized via #[serial] so no concurrent env access
         unsafe {
             std::env::remove_var("PICOLAYER_LOG_LEVEL");
         }
         // Falls through to default when parse fails
         assert_eq!(level, LevelFilter::Warn);
+    }
+
+    #[test]
+    fn get_log_level_quiet_returns_error() {
+        assert_eq!(get_log_level(0, true), LevelFilter::Error);
+    }
+
+    #[test]
+    fn get_log_level_verbose_1_returns_info() {
+        assert_eq!(get_log_level(1, false), LevelFilter::Info);
+    }
+
+    #[test]
+    fn get_log_level_verbose_2_returns_debug() {
+        assert_eq!(get_log_level(2, false), LevelFilter::Debug);
+    }
+
+    #[test]
+    fn get_log_level_verbose_3_returns_trace() {
+        assert_eq!(get_log_level(3, false), LevelFilter::Trace);
+    }
+
+    #[test]
+    #[serial]
+    fn get_log_level_cli_verbose_overrides_env() {
+        // SAFETY: serialized via #[serial] so no concurrent env access
+        unsafe {
+            std::env::set_var("PICOLAYER_LOG_LEVEL", "error");
+        }
+        let level = get_log_level(2, false);
+        unsafe {
+            std::env::remove_var("PICOLAYER_LOG_LEVEL");
+        }
+        assert_eq!(level, LevelFilter::Debug);
     }
 }


### PR DESCRIPTION
## Summary
- Add `-v` (info), `-vv` (debug), `-vvv` (trace) and `--quiet` (error-only) global flags
- CLI flags take precedence over env vars (`PICOLAYER_LOG_LEVEL`, `RUST_LOG`)
- Restructure boot sequence to parse CLI before initializing logging
- Add 5 new unit tests for verbosity flag behavior