### PR TITLE
refactor: centralize subprocess execution with stderr surfacing

### DIFF
--- a/src/installers/npm.rs
+++ b/src/installers/npm.rs
@@ -1,5 +1,5 @@
 use crate::utils;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use log::{debug, info};
 use std::process::Command;
 
@@ -32,25 +32,22 @@ fn install_nodejs() -> Result<()> {
 
 fn install_nodejs_debian() -> Result<()> {
     debug!("Installing Node.js on Debian-like system");
-    utils::sudo::command("apt-get")
-        .args(["update"])
-        .output()
-        .context("Failed to update package lists")?;
+    let mut cmd = utils::sudo::command("apt-get");
+    cmd.args(["update"]);
+    utils::subprocess::run_command(&mut cmd, "Update package lists")?;
 
-    utils::sudo::command("apt-get")
-        .args(["install", "-y", "nodejs", "npm"])
-        .output()
-        .context("Failed to install Node.js and npm")?;
+    let mut cmd = utils::sudo::command("apt-get");
+    cmd.args(["install", "-y", "nodejs", "npm"]);
+    utils::subprocess::run_command(&mut cmd, "Install Node.js and npm")?;
 
     Ok(())
 }
 
 fn install_nodejs_alpine() -> Result<()> {
     debug!("Installing Node.js on Alpine Linux");
-    utils::sudo::command("apk")
-        .args(["add", "nodejs", "npm"])
-        .output()
-        .context("Failed to install Node.js and npm")?;
+    let mut cmd = utils::sudo::command("apk");
+    cmd.args(["add", "nodejs", "npm"]);
+    utils::subprocess::run_command(&mut cmd, "Install Node.js and npm")?;
 
     Ok(())
 }
@@ -61,8 +58,7 @@ fn install_packages(packages: &[String]) -> Result<()> {
     let mut cmd = Command::new("npm");
     cmd.args(["install", "-g"]);
     cmd.args(packages);
-
-    cmd.output().context("Failed to install npm packages")?;
+    utils::subprocess::run_command(&mut cmd, "Install npm packages")?;
 
     info!("Successfully installed npm packages: {:?}", packages);
     Ok(())

--- a/src/installers/package_manager/apk.rs
+++ b/src/installers/package_manager/apk.rs
@@ -1,5 +1,5 @@
 use crate::utils;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use log::info;
 
 pub(super) fn install(packages: &[String]) -> Result<()> {
@@ -21,28 +21,24 @@ pub(super) fn install(packages: &[String]) -> Result<()> {
 
 fn update_repositories() -> Result<()> {
     info!("Updating apk repositories");
-    utils::sudo::command("apk")
-        .args(["update"])
-        .output()
-        .context("Failed to update apk repositories")?;
+    let mut cmd = utils::sudo::command("apk");
+    cmd.args(["update"]);
+    utils::subprocess::run_command(&mut cmd, "Update apk repositories")?;
     Ok(())
 }
 
 fn install_packages(packages: &[String]) -> Result<()> {
     info!("Installing apk packages: {:?}", packages);
-    utils::sudo::command("apk")
-        .args(["add", "--no-cache"])
-        .args(packages)
-        .output()
-        .context("Failed to install apk packages")?;
+    let mut cmd = utils::sudo::command("apk");
+    cmd.args(["add", "--no-cache"]).args(packages);
+    utils::subprocess::run_command(&mut cmd, "Install apk packages")?;
     Ok(())
 }
 
 fn cleanup() -> Result<()> {
     info!("Cleaning up apk cache");
-    utils::sudo::command("apk")
-        .args(["cache", "clean"])
-        .output()
-        .context("Failed to clean apk cache")?;
+    let mut cmd = utils::sudo::command("apk");
+    cmd.args(["cache", "clean"]);
+    utils::subprocess::run_command(&mut cmd, "Clean apk cache")?;
     Ok(())
 }

--- a/src/installers/package_manager/apt_based.rs
+++ b/src/installers/package_manager/apt_based.rs
@@ -1,5 +1,5 @@
 use crate::utils;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use log::{info, warn};
 
 use super::PackageManagerConfig;
@@ -47,27 +47,24 @@ pub(super) fn install_aptitude(packages: &[String]) -> Result<()> {
 
 fn update_repositories() -> Result<()> {
     info!("Updating repositories");
-    utils::sudo::command("apt-get")
-        .args(["update", "-y"])
-        .output()
-        .context("Failed to update repositories")?;
+    let mut cmd = utils::sudo::command("apt-get");
+    cmd.args(["update", "-y"]);
+    utils::subprocess::run_command(&mut cmd, "Update repositories")?;
     Ok(())
 }
 
 fn install_ppa_support() -> Result<()> {
     info!("Installing PPA support packages");
-    utils::sudo::command("apt-get")
-        .args(["install", "-y", "--no-install-recommends"])
-        .args(PPA_SUPPORT_PACKAGES)
-        .output()
-        .context("Failed to install PPA support packages")?;
+    let mut cmd = utils::sudo::command("apt-get");
+    cmd.args(["install", "-y", "--no-install-recommends"])
+        .args(PPA_SUPPORT_PACKAGES);
+    utils::subprocess::run_command(&mut cmd, "Install PPA support packages")?;
 
     if utils::os::is_debian() {
-        utils::sudo::command("apt-get")
-            .args(["install", "-y", "--no-install-recommends"])
-            .args(PPA_SUPPORT_PACKAGES_DEBIAN)
-            .output()
-            .context("Failed to install Debian PPA support packages")?;
+        let mut cmd = utils::sudo::command("apt-get");
+        cmd.args(["install", "-y", "--no-install-recommends"])
+            .args(PPA_SUPPORT_PACKAGES_DEBIAN);
+        utils::subprocess::run_command(&mut cmd, "Install Debian PPA support packages")?;
     }
     Ok(())
 }
@@ -75,57 +72,50 @@ fn install_ppa_support() -> Result<()> {
 fn add_ppas(ppas: &[String]) -> Result<()> {
     for ppa in ppas {
         info!("Adding PPA: {}", ppa);
-        utils::sudo::command("add-apt-repository")
-            .args(["-y", ppa])
-            .output()
-            .with_context(|| format!("Failed to add PPA: {}", ppa))?;
+        let mut cmd = utils::sudo::command("add-apt-repository");
+        cmd.args(["-y", ppa]);
+        utils::subprocess::run_command(&mut cmd, &format!("Add PPA: {}", ppa))?;
     }
     Ok(())
 }
 
 fn install_packages(tool: &str, packages: &[String]) -> Result<()> {
     info!("Installing packages with {}: {:?}", tool, packages);
-    utils::sudo::command(tool)
-        .args(["install", "-y", "--no-install-recommends"])
-        .args(packages)
-        .output()
-        .context("Failed to install packages")?;
+    let mut cmd = utils::sudo::command(tool);
+    cmd.args(["install", "-y", "--no-install-recommends"])
+        .args(packages);
+    utils::subprocess::run_command(&mut cmd, "Install packages")?;
     Ok(())
 }
 
 fn install_aptitude_tool() -> Result<()> {
     info!("Installing aptitude");
-    utils::sudo::command("apt-get")
-        .args(["install", "-y", "--no-install-recommends", "aptitude"])
-        .output()
-        .context("Failed to install aptitude")?;
+    let mut cmd = utils::sudo::command("apt-get");
+    cmd.args(["install", "-y", "--no-install-recommends", "aptitude"]);
+    utils::subprocess::run_command(&mut cmd, "Install aptitude")?;
     Ok(())
 }
 
 fn install_packages_aptitude(packages: &[String]) -> Result<()> {
     info!("Installing packages with aptitude: {:?}", packages);
-    utils::sudo::command("aptitude")
-        .args(["install", "-y"])
-        .args(packages)
-        .output()
-        .context("Failed to install packages with aptitude")?;
+    let mut cmd = utils::sudo::command("aptitude");
+    cmd.args(["install", "-y"]).args(packages);
+    utils::subprocess::run_command(&mut cmd, "Install packages with aptitude")?;
     Ok(())
 }
 
 fn cleanup() -> Result<()> {
     info!("Cleaning package cache");
-    utils::sudo::command("apt-get")
-        .args(["clean"])
-        .output()
-        .context("Failed to clean package cache")?;
+    let mut cmd = utils::sudo::command("apt-get");
+    cmd.args(["clean"]);
+    utils::subprocess::run_command(&mut cmd, "Clean package cache")?;
     Ok(())
 }
 
 fn cleanup_aptitude() -> Result<()> {
     info!("Cleaning aptitude cache");
-    utils::sudo::command("aptitude")
-        .args(["clean"])
-        .output()
-        .context("Failed to clean aptitude cache")?;
+    let mut cmd = utils::sudo::command("aptitude");
+    cmd.args(["clean"]);
+    utils::subprocess::run_command(&mut cmd, "Clean aptitude cache")?;
     Ok(())
 }

--- a/src/installers/package_manager/brew.rs
+++ b/src/installers/package_manager/brew.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Result};
+use crate::utils;
+use anyhow::Result;
 use log::info;
 
 pub(super) fn install(packages: &[String]) -> Result<()> {
@@ -16,28 +17,24 @@ pub(super) fn install(packages: &[String]) -> Result<()> {
 
 fn update() -> Result<()> {
     info!("Updating Homebrew");
-    std::process::Command::new("brew")
-        .arg("update")
-        .output()
-        .context("Failed to update Homebrew")?;
+    let mut cmd = std::process::Command::new("brew");
+    cmd.arg("update");
+    utils::subprocess::run_command(&mut cmd, "Update Homebrew")?;
     Ok(())
 }
 
 fn install_packages(packages: &[String]) -> Result<()> {
     info!("Installing Homebrew packages: {:?}", packages);
-    std::process::Command::new("brew")
-        .args(["install"])
-        .args(packages)
-        .output()
-        .context("Failed to install Homebrew packages")?;
+    let mut cmd = std::process::Command::new("brew");
+    cmd.args(["install"]).args(packages);
+    utils::subprocess::run_command(&mut cmd, "Install Homebrew packages")?;
     Ok(())
 }
 
 fn cleanup() -> Result<()> {
     info!("Cleaning up Homebrew cache");
-    std::process::Command::new("brew")
-        .arg("cleanup")
-        .output()
-        .context("Failed to clean up Homebrew cache")?;
+    let mut cmd = std::process::Command::new("brew");
+    cmd.arg("cleanup");
+    utils::subprocess::run_command(&mut cmd, "Clean up Homebrew cache")?;
     Ok(())
 }

--- a/src/installers/pipx.rs
+++ b/src/installers/pipx.rs
@@ -1,5 +1,5 @@
 use crate::utils;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use log::{debug, info};
 use std::process::Command;
 
@@ -32,30 +32,26 @@ fn install_pipx() -> Result<()> {
 
 fn install_pipx_debian() -> Result<()> {
     debug!("Installing pipx on Debian-like system");
-    utils::sudo::command("apt-get")
-        .args(["update"])
-        .output()
-        .context("Failed to update package lists")?;
+    let mut cmd = utils::sudo::command("apt-get");
+    cmd.args(["update"]);
+    utils::subprocess::run_command(&mut cmd, "Update package lists")?;
 
-    utils::sudo::command("apt-get")
-        .args(["install", "-y", "pipx"])
-        .output()
-        .context("Failed to install pipx")?;
+    let mut cmd = utils::sudo::command("apt-get");
+    cmd.args(["install", "-y", "pipx"]);
+    utils::subprocess::run_command(&mut cmd, "Install pipx")?;
 
     Ok(())
 }
 
 fn install_pipx_alpine() -> Result<()> {
     debug!("Installing pipx on Alpine Linux");
-    utils::sudo::command("apk")
-        .args(["add", "py3-pip", "python3"])
-        .output()
-        .context("Failed to install Python and pip")?;
+    let mut cmd = utils::sudo::command("apk");
+    cmd.args(["add", "py3-pip", "python3"]);
+    utils::subprocess::run_command(&mut cmd, "Install Python and pip")?;
 
-    Command::new("pip3")
-        .args(["install", "--user", "pipx"])
-        .output()
-        .context("Failed to install pipx via pip")?;
+    let mut cmd = Command::new("pip3");
+    cmd.args(["install", "--user", "pipx"]);
+    utils::subprocess::run_command(&mut cmd, "Install pipx via pip")?;
 
     Ok(())
 }
@@ -71,8 +67,7 @@ fn install_packages(packages: &[String], python_version: Option<&str>) -> Result
             cmd.args(["--python", version]);
         }
 
-        cmd.output()
-            .with_context(|| format!("Failed to install pipx package: {}", package))?;
+        utils::subprocess::run_command(&mut cmd, &format!("Install pipx package: {}", package))?;
     }
 
     info!("Successfully installed pipx packages: {:?}", packages);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod logging;
 pub mod os;
 pub mod retry;
+pub mod subprocess;
 pub mod sudo;

--- a/src/utils/subprocess.rs
+++ b/src/utils/subprocess.rs
@@ -1,0 +1,64 @@
+use anyhow::{Context, Result};
+use log::warn;
+use std::process::{Command, Output};
+
+/// Run a command, check its exit status, and log stderr/stdout on failure.
+pub fn run_command(cmd: &mut Command, description: &str) -> Result<Output> {
+    let output = cmd
+        .output()
+        .with_context(|| format!("Failed to execute: {}", description))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !stdout.is_empty() {
+            warn!("{} stdout:\n{}", description, stdout.trim());
+        }
+        if !stderr.is_empty() {
+            warn!("{} stderr:\n{}", description, stderr.trim());
+        }
+        anyhow::bail!(
+            "{} failed with exit code: {:?}",
+            description,
+            output.status.code()
+        );
+    }
+
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_command_succeeds_on_true() {
+        let output = run_command(&mut Command::new("true"), "true command").unwrap();
+        assert!(output.status.success());
+    }
+
+    #[test]
+    fn run_command_fails_on_false() {
+        let result = run_command(&mut Command::new("false"), "false command");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("false command failed with exit code"));
+    }
+
+    #[test]
+    fn run_command_captures_stderr_in_error() {
+        let result = run_command(
+            Command::new("sh").args(["-c", "echo err >&2; exit 1"]),
+            "stderr test",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn run_command_returns_output_on_success() {
+        let output =
+            run_command(Command::new("sh").args(["-c", "echo hello"]), "echo test").unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("hello"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `utils::subprocess::run_command()` utility that captures stderr/stdout on failure, logs them at `warn!` level, and bails with the exit code
- Migrate all installer modules (apt_based, apk, brew, npm, pipx) from inline `.output().context()` patterns to the centralized utility
- Includes 4 unit tests for the new subprocess module