### PR TITLE
docs: use arch-aware install.sh in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,24 @@ Refer to these examples to integrate the [Picolayer feature](https://github.com/
 cargo install --git https://github.com/skevetter/picolayer
 ```
 
-### From binary
+### Install script
 
-Download the latest release from the [releases page](https://github.com/skevetter/picolayer/releases).
-
-_Or download as a one-liner_
+The install script detects your OS and architecture (x86_64 and aarch64/arm64 are supported) and installs the matching release binary.
 
 ```bash
-curl -L https://github.com/skevetter/picolayer/releases/latest/download/picolayer-x86_64-unknown-linux-gnu.tar.gz | tar -xz && chmod +x picolayer && \
-./picolayer \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/bash-command:1" \
-    --option command="curl https://pkgx.sh | sh"
+curl -fsSL https://raw.githubusercontent.com/skevetter/picolayer/main/install.sh | bash
 ```
+
+Override the version or install directory with environment variables:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/skevetter/picolayer/main/install.sh | \
+    PICOLAYER_VERSION=v0.5.5 PICOLAYER_INSTALL_DIR="$HOME/.local/bin" bash
+```
+
+### From binary
+
+Download the latest release for your platform from the [releases page](https://github.com/skevetter/picolayer/releases).
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Replace the hardcoded `x86_64` install one-liner in the README with the existing arch-aware `install.sh` (`curl -fsSL ... | bash`), which already detects OS and architecture (x86_64 and aarch64/arm64).
- Document the `PICOLAYER_VERSION` and `PICOLAYER_INSTALL_DIR` environment-variable overrides.
- Simplify the "From binary" section to link the releases page.

This closes the only X86-hardcoded user-facing install path; the runtime asset selector, release builds, and CI already support ARM.